### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci-nixos.yml
+++ b/.github/workflows/ci-nixos.yml
@@ -42,7 +42,7 @@ jobs:
          sudo apt-get update -q -y && sudo apt-get install -q -y qemu-system-aarch64 qemu-efi binfmt-support qemu-user-static
       if: contains(matrix.hostname, 'oca')
     - name: Maximize build space
-      uses: easimon/maximize-build-space@v9
+      uses: easimon/maximize-build-space@v10
       with:
         remove-android: 'true'
         remove-dotnet: 'true'
@@ -50,13 +50,13 @@ jobs:
         #build-mount-path: /nix
         swap-size-mb: 1024
         root-reserve-mb: 50192
-    - uses: actions/checkout@v4
-    - uses: DeterminateSystems/nix-installer-action@v14
+    - uses: actions/checkout@v4.2.2
+    - uses: DeterminateSystems/nix-installer-action@v16
       with:
         extra-conf: |
           experimental-features = nix-command flakes
           extra-platforms = aarch64-linux arm-linux i686-linux
-    - uses: DeterminateSystems/flake-checker-action@v4
+    - uses: DeterminateSystems/flake-checker-action@v9
     - uses: DeterminateSystems/magic-nix-cache-action@v8
     - uses: cachix/cachix-action@v15
       with:

--- a/.github/workflows/update_flake.yml
+++ b/.github/workflows/update_flake.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.2.2
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v1
+        uses: DeterminateSystems/nix-installer-action@v16
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@v17
+        uses: DeterminateSystems/update-flake-lock@v24
         with:
           pr-title: "Update flake.lock" # Title of PR to be created
           pr-labels: |                  # Labels to be set on the PR


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[DeterminateSystems/update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock)** published a new release **[v24](https://github.com/DeterminateSystems/update-flake-lock/releases/tag/v24)** on 2024-09-09T16:48:08Z
* **[easimon/maximize-build-space](https://github.com/easimon/maximize-build-space)** published a new release **[v10](https://github.com/easimon/maximize-build-space/releases/tag/v10)** on 2023-12-07T16:52:24Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[DeterminateSystems/flake-checker-action](https://github.com/DeterminateSystems/flake-checker-action)** published a new release **[v9](https://github.com/DeterminateSystems/flake-checker-action/releases/tag/v9)** on 2024-09-09T16:44:48Z
* **[DeterminateSystems/nix-installer-action](https://github.com/DeterminateSystems/nix-installer-action)** published a new release **[v16](https://github.com/DeterminateSystems/nix-installer-action/releases/tag/v16)** on 2024-11-14T16:42:53Z
