### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci-nixos.yml
+++ b/.github/workflows/ci-nixos.yml
@@ -57,7 +57,7 @@ jobs:
           experimental-features = nix-command flakes
           extra-platforms = aarch64-linux arm-linux i686-linux
     - uses: DeterminateSystems/flake-checker-action@v9
-    - uses: DeterminateSystems/magic-nix-cache-action@v8
+    - uses: DeterminateSystems/magic-nix-cache-action@v9
     - uses: cachix/cachix-action@v15
       with:
         name: chr 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[DeterminateSystems/magic-nix-cache-action](https://github.com/DeterminateSystems/magic-nix-cache-action)** published a new release **[v9](https://github.com/DeterminateSystems/magic-nix-cache-action/releases/tag/v9)** on 2025-01-21T17:57:00Z
