### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci-nixos.yml
+++ b/.github/workflows/ci-nixos.yml
@@ -58,7 +58,7 @@ jobs:
           extra-platforms = aarch64-linux arm-linux i686-linux
     - uses: DeterminateSystems/flake-checker-action@v9
     - uses: DeterminateSystems/magic-nix-cache-action@v9
-    - uses: cachix/cachix-action@v15
+    - uses: cachix/cachix-action@v16
       with:
         name: chr 
         extraPullNames: 'nix-community, chaotic-nyx, cosmic'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[cachix/cachix-action](https://github.com/cachix/cachix-action)** published a new release **[v16](https://github.com/cachix/cachix-action/releases/tag/v16)** on 2025-03-10T18:55:40Z
