### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci-nixos.yml
+++ b/.github/workflows/ci-nixos.yml
@@ -51,7 +51,7 @@ jobs:
         swap-size-mb: 1024
         root-reserve-mb: 50192
     - uses: actions/checkout@v4.2.2
-    - uses: DeterminateSystems/nix-installer-action@v16
+    - uses: DeterminateSystems/nix-installer-action@v17
       with:
         extra-conf: |
           experimental-features = nix-command flakes

--- a/.github/workflows/update_flake.yml
+++ b/.github/workflows/update_flake.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v16
+        uses: DeterminateSystems/nix-installer-action@v17
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@v24
         with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[DeterminateSystems/nix-installer-action](https://github.com/DeterminateSystems/nix-installer-action)** published a new release **[v17](https://github.com/DeterminateSystems/nix-installer-action/releases/tag/v17)** on 2025-04-24T11:12:44Z
