### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci-nixos.yml
+++ b/.github/workflows/ci-nixos.yml
@@ -53,7 +53,7 @@ jobs:
         swap-size-mb: 1024
         root-reserve-mb: 50192
     - uses: actions/checkout@v4.2.2
-    - uses: DeterminateSystems/nix-installer-action@v17
+    - uses: DeterminateSystems/nix-installer-action@v18
       with:
         extra-conf: |
           experimental-features = nix-command flakes

--- a/.github/workflows/update_flake.yml
+++ b/.github/workflows/update_flake.yml
@@ -10,9 +10,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v17
+        uses: DeterminateSystems/nix-installer-action@v18
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@v25
+        uses: DeterminateSystems/update-flake-lock@v26
         with:
           pr-title: "Update flake.lock" # Title of PR to be created
           pr-labels: |                  # Labels to be set on the PR


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[DeterminateSystems/nix-installer-action](https://github.com/DeterminateSystems/nix-installer-action)** published a new release **[v18](https://github.com/DeterminateSystems/nix-installer-action/releases/tag/v18)** on 2025-07-03T13:44:28Z
* **[DeterminateSystems/update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock)** published a new release **[v26](https://github.com/DeterminateSystems/update-flake-lock/releases/tag/v26)** on 2025-07-03T13:42:19Z
