### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci-nixos.yml
+++ b/.github/workflows/ci-nixos.yml
@@ -52,8 +52,8 @@ jobs:
         #build-mount-path: /nix
         swap-size-mb: 1024
         root-reserve-mb: 50192
-    - uses: actions/checkout@v5.0.0
-    - uses: DeterminateSystems/nix-installer-action@v20
+    - uses: actions/checkout@v6.0.0
+    - uses: DeterminateSystems/nix-installer-action@v21
       with:
         extra-conf: |
           experimental-features = nix-command flakes

--- a/.github/workflows/update_flake.yml
+++ b/.github/workflows/update_flake.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v6.0.0
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v20
+        uses: DeterminateSystems/nix-installer-action@v21
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@v27
+        uses: DeterminateSystems/update-flake-lock@v28
         with:
           pr-title: "Update flake.lock" # Title of PR to be created
           pr-labels: |                  # Labels to be set on the PR

--- a/.github/workflows/update_workflow.yml
+++ b/.github/workflows/update_workflow.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.0
         with:
           token: ${{ secrets.TOKEN }}
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[DeterminateSystems/nix-installer-action](https://github.com/DeterminateSystems/nix-installer-action)** published a new release **[v21](https://github.com/DeterminateSystems/nix-installer-action/releases/tag/v21)** on 2025-11-12T14:16:39Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.0](https://github.com/actions/checkout/releases/tag/v6.0.0)** on 2025-11-20T16:24:08Z
* **[DeterminateSystems/update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock)** published a new release **[v28](https://github.com/DeterminateSystems/update-flake-lock/releases/tag/v28)** on 2025-11-26T21:23:21Z
