### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci-nixos.yml
+++ b/.github/workflows/ci-nixos.yml
@@ -59,7 +59,7 @@ jobs:
         docker-images: true
         swap-storage: true
     - uses: actions/checkout@v6.0.2
-    - uses: DeterminateSystems/nix-installer-action@v21
+    - uses: DeterminateSystems/nix-installer-action@v22
       with:
         extra-conf: |
           experimental-features = nix-command flakes

--- a/.github/workflows/update_flake.yml
+++ b/.github/workflows/update_flake.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v21
+        uses: DeterminateSystems/nix-installer-action@v22
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@v28
         with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[DeterminateSystems/nix-installer-action](https://github.com/DeterminateSystems/nix-installer-action)** published a new release **[v22](https://github.com/DeterminateSystems/nix-installer-action/releases/tag/v22)** on 2026-03-29T17:42:38Z
