### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci-nixos.yml
+++ b/.github/workflows/ci-nixos.yml
@@ -64,7 +64,7 @@ jobs:
         extra-conf: |
           experimental-features = nix-command flakes
           extra-platforms = aarch64-linux arm-linux i686-linux
-    - uses: DeterminateSystems/flake-checker-action@v12
+    - uses: DeterminateSystems/flake-checker-action@v13
     - uses: DeterminateSystems/magic-nix-cache-action@v14
     - uses: cachix/cachix-action@v17
       with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[DeterminateSystems/flake-checker-action](https://github.com/DeterminateSystems/flake-checker-action)** published a new release **[v13](https://github.com/DeterminateSystems/flake-checker-action/releases/tag/v13)** on 2026-07-16T13:45:37Z
